### PR TITLE
Tested fix for repeat count detection not resetting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "homebridge-unipi",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "HomeBridge Plugin for the UniPi Neuron Devices",
 	"keywords": [
 		"homebridge-plugin",

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,10 +1,13 @@
 ---
 author: Daan Kets <daankets@blackbit.be>
-version: 1.1.1
+version: 1.1.2
 title: HomeBridge UniPi Plugin for Evok API
 ---
 
 # Release notes
+
+## 1.1.2
+This bugfix release fixes a problem with the 'stuck-button' detection, the would prevent the detection counter from being reset on button release. 
 
 ## 1.1.1
 This versions adds a feature for preventing unlimited repeated 'long press' events from firing an event. This feature is handy to prevent unlimited switching on/off of a target device when a button gets stuck. The default value limits the long press repeat to *10*.

--- a/src/model/unipi-accessory.model.js
+++ b/src/model/unipi-accessory.model.js
@@ -435,6 +435,7 @@ module.exports.UniPiAccessory = class UniPiAccessory {
 					} else if (state.longPressRelease) {
 						// DISABLED this.log("IGNORE LONG PRESS RELEASE", digInId);
 						state.longPressRelease = false;
+						state.repeatCount = 0;
 					} else {
 						// DISABLED this.log("SINGLE PRESS", digInId, "in", (this.$config.doublePressMaxDelay || 500), "ms");
 						state.cancelTimer = setTimeout(() => {


### PR DESCRIPTION
Fix for an issue with 1.1.1: The counter for detecting repeated long presses was not resetting correctly.